### PR TITLE
Move plugin-simpler::error code back to gst-plugin

### DIFF
--- a/gst-plugin-file/src/filesink.rs
+++ b/gst-plugin-file/src/filesink.rs
@@ -12,6 +12,7 @@ use url::Url;
 
 use std::io::Write;
 
+use gst_plugin::error::*;
 use gst_plugin_simple::error::*;
 use gst_plugin_simple::sink::*;
 use gst_plugin_simple::UriValidator;

--- a/gst-plugin-file/src/filesrc.rs
+++ b/gst-plugin-file/src/filesrc.rs
@@ -11,6 +11,7 @@ use std::io::{Read, Seek, SeekFrom};
 use std::u64;
 use url::Url;
 
+use gst_plugin::error::*;
 use gst_plugin_simple::error::*;
 use gst_plugin_simple::source::*;
 use gst_plugin_simple::UriValidator;

--- a/gst-plugin-flv/src/flvdemux.rs
+++ b/gst-plugin-flv/src/flvdemux.rs
@@ -17,8 +17,8 @@ use flavors::parser as flavors;
 use gst_plugin::adapter::*;
 use gst_plugin::bytes::*;
 use gst_plugin::element::*;
+use gst_plugin::error::*;
 use gst_plugin_simple::demuxer::*;
-use gst_plugin_simple::error::*;
 
 use gst;
 

--- a/gst-plugin-http/src/httpsrc.rs
+++ b/gst-plugin-http/src/httpsrc.rs
@@ -13,6 +13,8 @@ use std::io::Read;
 use std::u64;
 use url::Url;
 
+use gst_plugin::error::*;
+
 use gst_plugin_simple::error::*;
 use gst_plugin_simple::source::*;
 use gst_plugin_simple::UriValidator;

--- a/gst-plugin-simple/src/demuxer.rs
+++ b/gst-plugin-simple/src/demuxer.rs
@@ -14,8 +14,7 @@ use std::u64;
 
 use gobject_subclass::object::*;
 use gst_plugin::element::*;
-
-use error::*;
+use gst_plugin::error::*;
 
 use gst;
 use gst::prelude::*;

--- a/gst-plugin-simple/src/error.rs
+++ b/gst-plugin-simple/src/error.rs
@@ -13,54 +13,6 @@ use std::fmt::{Display, Formatter};
 use glib;
 use gst;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum FlowError {
-    Flushing,
-    Eos,
-    NotNegotiated(gst::ErrorMessage),
-    Error(gst::ErrorMessage),
-}
-
-impl Into<gst::FlowReturn> for FlowError {
-    fn into(self) -> gst::FlowReturn {
-        (&self).into()
-    }
-}
-
-impl<'a> Into<gst::FlowReturn> for &'a FlowError {
-    fn into(self) -> gst::FlowReturn {
-        match *self {
-            FlowError::Flushing => gst::FlowReturn::Flushing,
-            FlowError::Eos => gst::FlowReturn::Eos,
-            FlowError::NotNegotiated(..) => gst::FlowReturn::NotNegotiated,
-            FlowError::Error(..) => gst::FlowReturn::Error,
-        }
-    }
-}
-
-impl Display for FlowError {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
-        match *self {
-            FlowError::Flushing | FlowError::Eos => f.write_str(self.description()),
-            FlowError::NotNegotiated(ref m) => {
-                f.write_fmt(format_args!("{}: {}", self.description(), m))
-            }
-            FlowError::Error(ref m) => f.write_fmt(format_args!("{}: {}", self.description(), m)),
-        }
-    }
-}
-
-impl Error for FlowError {
-    fn description(&self) -> &str {
-        match *self {
-            FlowError::Flushing => "Flushing",
-            FlowError::Eos => "Eos",
-            FlowError::NotNegotiated(..) => "Not Negotiated",
-            FlowError::Error(..) => "Error",
-        }
-    }
-}
-
 #[derive(Debug, PartialEq, Eq)]
 pub struct UriError {
     error: gst::URIError,

--- a/gst-plugin-simple/src/sink.rs
+++ b/gst-plugin-simple/src/sink.rs
@@ -20,6 +20,7 @@ use gobject_subclass::object::*;
 use gst_plugin::base_sink::*;
 use gst_plugin::element::*;
 use gst_plugin::uri_handler::*;
+use gst_plugin::error::*;
 
 pub use gst_plugin::base_sink::BaseSink;
 

--- a/gst-plugin-simple/src/source.rs
+++ b/gst-plugin-simple/src/source.rs
@@ -22,6 +22,7 @@ use gobject_subclass::object::*;
 use gst_plugin::base_src::*;
 use gst_plugin::element::*;
 use gst_plugin::uri_handler::*;
+use gst_plugin::error::*;
 
 pub use gst_plugin::base_src::BaseSrc;
 


### PR DESCRIPTION
Prepatory work to write element base class for decoders (which will be
outside of plugin-simple).